### PR TITLE
Remove : from # headers, 04-communication-plan.md

### DIFF
--- a/04-communication-plan.md
+++ b/04-communication-plan.md
@@ -48,7 +48,7 @@ how often will we get in touch on each channel, and what we will discuss there:
 | ------ | :-----: | :-----: | :-------: | :------: | :-----: | :------: | :-----: |
 | _name_ | 13 - 20 | 13 - 20 |  13 - 20  | 13 - 20  | 13 - 20 | 13 - 20  | 13 - 20 |
 
-### How many hours everyone has per day:
+### How many hours everyone has per day
 
 - name: _5h_; extra comments?
 - name: _6h_;


### PR DESCRIPTION
Remove `:` from # headers in 04-communication-plan.md to avoid linting error `no-trailing-punctuation Trailing punctuation in heading [Punctuation: ':']`